### PR TITLE
Add instructions for installing binary via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ This will put `ingress2gateway` binary in `$(go env GOPATH)/bin`
 
 Alternatively, you can download the binary at the [releases page](https://github.com/kubernetes-sigs/ingress2gateway/releases)
 
+### On macOS and linux via Homebrew:
+Make sure Homebrew is installed on your system.
+```shell
+brew install ingress2gateway
+```
+
 ### Build from Source
 
 1. Ensure that your system meets the following requirements:


### PR DESCRIPTION
Added instructions for installing the binary via Homebrew on macOS and Linux to
make it easier for users to obtain the `ingress2gateway` binary. This provides
an alternative method to building from the source.